### PR TITLE
fix+feat: correct name and add help

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A command line utility for unpacking .rar files.
 
 ```text
 USAGE
-	unrar <archive.rar> [./dst/]
+	runzip <archive.rar> [./dst/]
 
 EXAMPLES
-	unrar ./archive.rar                 # ./inner-dir/
-	unrar ./archive.rar ./existing-dir/ # ./existing-dir/inner-dir/
-	unrar ./archive.rar ./new-dir/      # ./new-dir/
+	runzip ./archive.rar                 # ./inner-dir/
+	runzip ./archive.rar ./existing-dir/ # ./existing-dir/inner-dir/
+	runzip ./archive.rar ./new-dir/      # ./new-dir/
 ```
 
 For archives with a single file or folder, this will extract that to the given directory.

--- a/runzip.go
+++ b/runzip.go
@@ -13,8 +13,8 @@ import (
 func main() {
 	nArgs := len(os.Args)
 	if nArgs < 2 || nArgs > 3 {
-		fmt.Printf("USAGE\n\tunrar <archive.rar> [./dst/]\n\n")
-		fmt.Printf("EXAMPLES\n\tunrar ./archive.rar\n\tunrar ./archive.rar ./unpacked/\n\n")
+		fmt.Printf("USAGE\n\trunzip <archive.rar> [./dst/]\n\n")
+		fmt.Printf("EXAMPLES\n\trunzip ./archive.rar\n\trunzip ./archive.rar ./unpacked/\n\n")
 		os.Exit(1)
 		return
 	}
@@ -56,7 +56,7 @@ func main() {
 
 	fmt.Fprintf(os.Stderr, "extracting to temporary path '%s/'...\n", tmpRel)
 
-	topLevelFiles, err := unrar(rarFile, tmpDir)
+	topLevelFiles, err := runzip(rarFile, tmpDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: could not unarchive: %v\n", err)
 		os.Exit(1)
@@ -74,7 +74,7 @@ func main() {
 	fmt.Fprintf(os.Stderr, "extracted to '%s/'\n", finalRel)
 }
 
-func unrar(rarFile, absRoot string) ([]string, error) {
+func runzip(rarFile, absRoot string) ([]string, error) {
 	var err error
 	topLevelFiles := []string{}
 

--- a/runzip.go
+++ b/runzip.go
@@ -10,11 +10,47 @@ import (
 	"github.com/nwaples/rardecode"
 )
 
+var (
+	name = "runzip"
+	// these will be replaced by goreleaser
+	version = "0.0.0"
+	date    = "0001-01-01T00:00:00Z"
+	commit  = "0000000"
+)
+
+func printVersion() {
+	fmt.Printf("%s v%s %s (%s)\n", name, version, commit[:7], date)
+	fmt.Printf("Copyright (C) 2024 AJ ONeal\n")
+	fmt.Printf("Licensed under the BSD 2-clause license\n")
+}
+
+func printUsage() {
+	fmt.Printf("%s v%s %s (%s)\n", name, version, commit[:7], date)
+	fmt.Printf("\n")
+	fmt.Printf("USAGE\n\trunzip <archive.rar> [./dst/]\n\n")
+	fmt.Printf("EXAMPLES\n\trunzip ./archive.rar\n\trunzip ./archive.rar ./unpacked/\n\n")
+}
+
 func main() {
 	nArgs := len(os.Args)
+
+	if nArgs >= 2 {
+		opt := os.Args[1]
+		subcmd := strings.TrimPrefix(opt, "-")
+		if opt == "-V" || subcmd == "version" {
+			printVersion()
+			os.Exit(0)
+			return
+		}
+		if subcmd == "help" {
+			printUsage()
+			os.Exit(0)
+			return
+		}
+	}
+
 	if nArgs < 2 || nArgs > 3 {
-		fmt.Printf("USAGE\n\trunzip <archive.rar> [./dst/]\n\n")
-		fmt.Printf("EXAMPLES\n\trunzip ./archive.rar\n\trunzip ./archive.rar ./unpacked/\n\n")
+		printUsage()
 		os.Exit(1)
 		return
 	}


### PR DESCRIPTION
- now calls itself `runzip` instead of the pre-release draft name
- now shows version and help with `-V`,`--version`,`version` and `--help`,`help`